### PR TITLE
Update MediaPickerHandler.php

### DIFF
--- a/src/FormFields/MediaPickerHandler.php
+++ b/src/FormFields/MediaPickerHandler.php
@@ -23,7 +23,11 @@ class MediaPickerHandler extends AbstractHandler
                 $content = json_encode('[]');
             }
         } else {
-            $content = "'".$dataTypeContent->{$row->field}."'";
+            //////////////////////
+            /// If filename contains a simple quote ', the field is not edited in the BREAD.
+            ///    With addslashes, it's OK
+            //////////////////////
+            $content = "'".addslashes($dataTypeContent->{$row->field})."'";
         }
 
         if (isset($options->base_path)) {


### PR DESCRIPTION
In the BREAD, design a mediapicker field.
Add a file which name contains a simple quote.
No problem to add.
![image](https://github.com/toto975/voyager/assets/104444110/061d4795-fe68-4a07-87f2-79b151b983bf)


But when editing, only the field's label appears.
![image](https://github.com/toto975/voyager/assets/104444110/c2f467a6-b3d6-409a-8142-11d2f5fb49c5)
