### PR TITLE
Update manager.blade.php

### DIFF
--- a/resources/views/media/manager.blade.php
+++ b/resources/views/media/manager.blade.php
@@ -573,7 +573,11 @@
             },
             filter: function(file) {
                 if (this.allowedTypes.length > 0) {
-                    if (file.type != 'folder') {
+                    //////////////////////////////
+                    /// Under Windows, the 'Thumbs.db' files have a file.type = null, which goes to an error for the test if (file.type.includes(type))
+                    /// We exclude them to display
+                    //////////////////////////////
+                    if (file.type != 'folder' && file.name != 'Thumbs.db') {
                         for (var i = 0, type; type = this.allowedTypes[i]; i++) {
                             if (file.type.includes(type)) {
                                 return true;


### PR DESCRIPTION
Add a media picker field to a bread.
In the media picker, when choosing a folder which contains a 'Thumbs.db' file, there's this javascript error

![image](https://github.com/toto975/voyager/assets/104444110/c6cf153d-53bb-4af6-acde-2a80ddcdd11d)

Under Windows, the 'Thumbs.db' files have a file.type = null, which goes to an error for the test
`if (file.type.includes(type))`
We exclude them to display.